### PR TITLE
Fix loginWithAuthorizationCode confidential request

### DIFF
--- a/packages/sdk-iam/src/custom/clients/IamUserAuthorizationClient.ts
+++ b/packages/sdk-iam/src/custom/clients/IamUserAuthorizationClient.ts
@@ -89,7 +89,8 @@ export class IamUserAuthorizationClient {
         'Device-Id': deviceId,
         'Device-Name': platform.name ? platform.name.toString() : '',
         'Device-Os': platform.os ? platform.os.toString() : '',
-        'Device-Type': SdkDevice.getType()
+        'Device-Type': SdkDevice.getType(),
+        ...this.conf.headers
       }
     }
     const axios = Network.create(config)


### PR DESCRIPTION
Confidential IAM client headers like `Authorization: 'Basic ...'` are not passing through the SDK configuration to the `loginWithAuthorizationCode` request.